### PR TITLE
fix: ensure datetimes are fixed width

### DIFF
--- a/src/main/java/org/cardanofoundation/signify/app/Exchanging.java
+++ b/src/main/java/org/cardanofoundation/signify/app/Exchanging.java
@@ -185,8 +185,7 @@ public class Exchanging {
     ) throws DigestException {
         String vs = CoreUtil.versify(CoreUtil.Ident.KERI, null, CoreUtil.Serials.JSON, 0);
         String ilk = CoreUtil.Ilks.EXN.getValue();
-        String dt = date != null ? date :
-                new Date().toInstant().toString().replace("Z", "000+00:00");
+        String dt = date != null ? date : Utils.currentDateTimeString();
         String p = dig != null ? dig : "";
         Map<String, Object> q = modifiers != null ? modifiers : new LinkedHashMap<>();
         Map<String, List<Object>> ems = embeds != null ? embeds : new LinkedHashMap<>();

--- a/src/main/java/org/cardanofoundation/signify/app/clienting/SignifyClient.java
+++ b/src/main/java/org/cardanofoundation/signify/app/clienting/SignifyClient.java
@@ -250,7 +250,7 @@ public class SignifyClient implements IdentifierDeps, OperationsDeps {
         Map<String, String> headers = new LinkedHashMap<>();
         Map<String, String> signedHeaders;
         headers.put("signify-resource", this.controller.getPre());
-        headers.put("signify-timestamp", new Date().toInstant().toString().replace("Z", "000+00:00"));
+        headers.put("signify-timestamp", Utils.currentDateTimeString());
         headers.put("content-type", "application/json");
 
         Object _body = method.equals("GET") ? null : Utils.jsonStringify(data);

--- a/src/main/java/org/cardanofoundation/signify/cesr/util/Utils.java
+++ b/src/main/java/org/cardanofoundation/signify/cesr/util/Utils.java
@@ -1,8 +1,6 @@
 package org.cardanofoundation.signify.cesr.util;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cardanofoundation.signify.app.config.GeneratedModelConfig;
 import org.cardanofoundation.signify.cesr.*;
@@ -12,6 +10,9 @@ import org.cardanofoundation.signify.cesr.exceptions.material.InvalidValueExcept
 import org.cardanofoundation.signify.cesr.exceptions.serialize.SerializeException;
 
 import java.math.BigInteger;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 public class Utils {
@@ -113,8 +114,17 @@ public class Utils {
         return System.currentTimeMillis() / 1000;
     }
 
+    // KERI datetimes are fixed-width with exactly 6 fraction digits;
+    // Instant.toString() drops the fraction entirely on whole seconds.
+    private static final DateTimeFormatter KERI_DATETIME_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSS'+00:00'").withZone(ZoneOffset.UTC);
+
     public static String currentDateTimeString() {
-        return new Date().toInstant().toString().replace("Z", "000+00:00");
+        return toDateTimeString(Instant.now());
+    }
+
+    public static String toDateTimeString(Instant instant) {
+        return KERI_DATETIME_FORMATTER.format(instant);
     }
 
 

--- a/src/main/java/org/cardanofoundation/signify/core/Eventing.java
+++ b/src/main/java/org/cardanofoundation/signify/core/Eventing.java
@@ -329,7 +329,7 @@ public class Eventing {
         _sad.put("v", vs);
         _sad.put("t", Ilks.RPY.getValue());
         _sad.put("d", "");
-        _sad.put("dt", stamp != null ? stamp : new Date().toInstant().toString().replace("Z", "000+00:00"));
+        _sad.put("dt", stamp != null ? stamp : Utils.currentDateTimeString());
         _sad.put("r", route);
         _sad.put("a", data);
 

--- a/src/test/java/org/cardanofoundation/signify/app/BaseMockServerTest.java
+++ b/src/test/java/org/cardanofoundation/signify/app/BaseMockServerTest.java
@@ -9,6 +9,7 @@ import org.cardanofoundation.signify.cesr.exceptions.LibsodiumException;
 import org.cardanofoundation.signify.core.Authenticater;
 import org.cardanofoundation.signify.cesr.Salter;
 import org.cardanofoundation.signify.cesr.Signer;
+import org.cardanofoundation.signify.cesr.util.Utils;
 import org.cardanofoundation.signify.core.Httping;
 import org.cardanofoundation.signify.generated.keria.model.Tier;
 import org.jetbrains.annotations.NotNull;
@@ -380,7 +381,7 @@ public class BaseMockServerTest {
     public MockResponse mockAllRequests(RecordedRequest req) throws LibsodiumException {
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put("signify-resource", "EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei");
-        headers.put(Httping.HEADER_SIG_TIME, new Date().toInstant().toString().replace("Z", "000+00:00"));
+        headers.put(Httping.HEADER_SIG_TIME, Utils.currentDateTimeString());
         headers.put("content-type", "application/json");
 
         String reqUrl = req.getRequestUrl().toString();

--- a/src/test/java/org/cardanofoundation/signify/app/CredentialingTest.java
+++ b/src/test/java/org/cardanofoundation/signify/app/CredentialingTest.java
@@ -27,7 +27,7 @@ public class CredentialingTest extends BaseMockServerTest {
     public MockResponse mockAllRequests(RecordedRequest req) throws LibsodiumException {
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put("signify-resource", "EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei");
-        headers.put(Httping.HEADER_SIG_TIME, new Date().toInstant().toString().replace("Z", "000+00:00"));
+        headers.put(Httping.HEADER_SIG_TIME, Utils.currentDateTimeString());
         headers.put("content-type", "application/json");
 
         String reqUrl = req.getRequestUrl().toString();

--- a/src/test/java/org/cardanofoundation/signify/cesr/util/UtilsTest.java
+++ b/src/test/java/org/cardanofoundation/signify/cesr/util/UtilsTest.java
@@ -82,4 +82,18 @@ public class UtilsTest {
 
         assertArrayEquals(expected, result, "The concatenated array is not as expected.");
     }
+
+    @Test
+    public void testDateTimeStringIsFixedWidth() {
+        // Whole-second instants must still produce the 6-digit fraction KERI requires
+        assertEquals(
+                "2026-06-10T06:53:58.000000+00:00",
+                Utils.toDateTimeString(java.time.Instant.parse("2026-06-10T06:53:58Z")));
+        assertEquals(
+                "2026-06-10T06:53:58.166000+00:00",
+                Utils.toDateTimeString(java.time.Instant.parse("2026-06-10T06:53:58.166Z")));
+
+        String now = Utils.currentDateTimeString();
+        assertEquals(32, now.length(), "KERI datetime must be fixed-width: " + now);
+    }
 }

--- a/src/test/java/org/cardanofoundation/signify/e2e/MultisigTest.java
+++ b/src/test/java/org/cardanofoundation/signify/e2e/MultisigTest.java
@@ -526,7 +526,7 @@ public class MultisigTest extends BaseIntegrationTest {
         Map<String, Object> vcdata = new HashMap<>();
         vcdata.put("LEI", "5493001KJTIIGC8Y1R17");
         String holder = aid4.getPrefix();
-        String TIME = new Date().toInstant().toString().replace("Z", "000+00:00");
+        String TIME = Utils.currentDateTimeString();
 
         CredentialData.CredentialSubject subject = CredentialData.CredentialSubject.builder()
                 .i(holder)
@@ -619,7 +619,7 @@ public class MultisigTest extends BaseIntegrationTest {
 
         // IPEX grant message
         System.out.println("Starting grant message");
-        String stamp = new Date().toInstant().toString().replace("Z", "000+00:00");
+        String stamp = Utils.currentDateTimeString();
 
         Exchanging.ExchangeMessageResult grantResult = client1.ipex().grant(IpexGrantArgs.builder()
                 .senderName("multisig")
@@ -798,7 +798,7 @@ public class MultisigTest extends BaseIntegrationTest {
         warnNotifications(List.of(client1, client2, client3, client4));
 
         System.out.println("Revoking credential...");
-        String REVTIME = new Date().toInstant().toString().replace("Z", "000+00:00");
+        String REVTIME = Utils.currentDateTimeString();
         RevokeCredentialResult revokeRes = client1.credentials().revoke("multisig", credentialSaid, REVTIME);
         op1 = revokeRes.getOp();
 


### PR DESCRIPTION
Sometimes you may get an error like this on KERIA:
```
          File "/keria/venv/lib/python3.12/site-packages/keri/core/routing.py", line 257, in acceptReply                                                                                                                                                                                                                    
            dater = coring.Dater(dts=serder.ked["dt"])                                                                                                                                                                                                                                                                      
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                      
          File "/keria/venv/lib/python3.12/site-packages/keri/core/coring.py", line 1991, in __init__                                                                                                                                                                                                                       
            super(Dater, self).__init__(raw=raw, qb64b=qb64b, qb64=qb64, qb2=qb2,                                                                                                                                                                                                                                           
          File "/keria/venv/lib/python3.12/site-packages/keri/core/coring.py", line 1006, in __init__                                                                                                                                                                                                                       
            self._exfil(qb64)                                                                                                                                                                                                                                                                                               
          File "/keria/venv/lib/python3.12/site-packages/keri/core/coring.py", line 1414, in _exfil                                                                                                                                                                                                                         
            raise ShortageError(f"Need {fs - len(qb64b)} more chars.")                                                                                                                                                                                                                                                      
        keri.kering.ShortageError: Need 4 more chars.
```

The problem was Signify was stripping off trailing zeros when landing on the second exactly, so dt values were too short.