### PR TITLE
fix: replace KeyStateRecordKt raw-value side-channel with typed KtValue

### DIFF
--- a/src/main/java/org/cardanofoundation/signify/app/aiding/IdentifierController.java
+++ b/src/main/java/org/cardanofoundation/signify/app/aiding/IdentifierController.java
@@ -1,6 +1,7 @@
 package org.cardanofoundation.signify.app.aiding;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.cardanofoundation.signify.app.config.KtValue;
 import org.cardanofoundation.signify.cesr.Keeping;
 import org.cardanofoundation.signify.cesr.Serder;
 import org.cardanofoundation.signify.cesr.Codex.MatterCodex;
@@ -395,7 +396,7 @@ public class IdentifierController {
         String dig = state.getD();
         int ridx = Integer.parseInt(state.getS(), 16) + 1;
         List<String> wits = state.getB();
-        Object isith = org.cardanofoundation.signify.app.config.KeyStateRecordKtDeserializer.getRawValue(state.getNt());
+        Object isith = KtValue.rawOf(state.getNt());
         Object nsith = kargs.getNsith() != null ? kargs.getNsith() : isith;
 
         // if isith is None:  # compute default from newly rotated verfers above

--- a/src/main/java/org/cardanofoundation/signify/app/config/KeyStateRecordKtDeserializer.java
+++ b/src/main/java/org/cardanofoundation/signify/app/config/KeyStateRecordKtDeserializer.java
@@ -4,37 +4,28 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import org.cardanofoundation.signify.generated.keria.model.KeyStateRecordKt;
+
 import java.io.IOException;
-import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.List;
 
-public class KeyStateRecordKtDeserializer extends JsonDeserializer<KeyStateRecordKt> {
-    // WeakHashMap to avoid memory leaks (keys are GC'd when no longer referenced)
-    private static final Map<KeyStateRecordKt, Object> rawValueMap = new WeakHashMap<>();
-
-    public static Object getRawValue(KeyStateRecordKt instance) {
-        return rawValueMap.get(instance);
-    }
+/**
+ * Deserializes the polymorphic {@code kt}/{@code nt} fields into a {@link KtValue}.
+ * KERIA returns these as either a plain string (unweighted) or an array of weights (weighted).
+ */
+class KeyStateRecordKtDeserializer extends JsonDeserializer<KeyStateRecordKt> {
 
     @Override
     public KeyStateRecordKt deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        Object value;
         switch (p.currentToken()) {
             case VALUE_STRING:
-                value = p.getValueAsString();
-                break;
+            case VALUE_NUMBER_INT: // tolerated; signify-ts types thresholds as string | number
+                return KtValue.unweighted(p.getValueAsString());
             case START_ARRAY:
-                value = ctxt.readValue(p, Object.class); // parse array
-                break;
-            case START_OBJECT:
-                value = ctxt.readValue(p, Object.class); // parse object
-                break;
+                return KtValue.weighted(ctxt.readValue(p, List.class));
             default:
-                value = null;
-                break;
+                return ctxt.reportInputMismatch(KeyStateRecordKt.class,
+                    "Cannot deserialize kt/nt threshold from token %s; expected a string or an array of weights",
+                    p.currentToken());
         }
-        KeyStateRecordKt instance = new KeyStateRecordKt();
-        rawValueMap.put(instance, value);
-        return instance;
     }
 }

--- a/src/main/java/org/cardanofoundation/signify/app/config/KeyStateRecordKtMixIn.java
+++ b/src/main/java/org/cardanofoundation/signify/app/config/KeyStateRecordKtMixIn.java
@@ -1,6 +1,0 @@
-package org.cardanofoundation.signify.app.config;
-
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-
-@JsonDeserialize(using = KeyStateRecordKtDeserializer.class)
-public abstract class KeyStateRecordKtMixIn {}

--- a/src/main/java/org/cardanofoundation/signify/app/config/KtValue.java
+++ b/src/main/java/org/cardanofoundation/signify/app/config/KtValue.java
@@ -1,0 +1,127 @@
+package org.cardanofoundation.signify.app.config;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.cardanofoundation.signify.generated.keria.model.KeyStateRecordKt;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Concrete representation of a KERI signing threshold ({@code kt}/{@code nt} fields).
+ * KERIA returns these as either a plain string (unweighted, e.g. {@code "2"}) or a list
+ * of fraction weights (weighted, e.g. {@code ["1/2", "1/2"]}, possibly nested for
+ * multi-clause thresholds). Discriminate with an exhaustive switch:
+ *
+ * <pre>{@code
+ * switch (KtValue.of(state.getKt())) {
+ *     case KtValue.Unweighted u -> u.threshold();
+ *     case KtValue.Weighted w -> w.weights();
+ * }
+ * }</pre>
+ */
+public abstract sealed class KtValue extends KeyStateRecordKt {
+
+    private KtValue() {
+    }
+
+    public static Unweighted unweighted(String threshold) {
+        return new Unweighted(threshold);
+    }
+
+    public static Weighted weighted(List<?> weights) {
+        return new Weighted(weights);
+    }
+
+    /**
+     * Narrows a generated {@code kt}/{@code nt} field to a {@link KtValue}. Every value
+     * deserialized off the wire is one; throws on programmatically constructed
+     * {@link KeyStateRecordKt} instances that carry no threshold.
+     */
+    public static KtValue of(KeyStateRecordKt value) {
+        if (value instanceof KtValue ktValue) {
+            return ktValue;
+        }
+        throw new IllegalArgumentException("kt/nt value carries no threshold: " + value);
+    }
+
+    /**
+     * Null-safe extraction of the raw threshold from a generated model field.
+     * Returns {@code null} when the field is absent or carries no threshold.
+     */
+    public static Object rawOf(KeyStateRecordKt value) {
+        return value instanceof KtValue ktValue ? ktValue.raw() : null;
+    }
+
+    /**
+     * Returns the raw value as KERIA sent it and as CESR utilities such as
+     * {@code Tholder} expect it: a {@code String} for unweighted, or a {@code List}
+     * for weighted. Also used by Jackson so serialization round-trips the
+     * original JSON instead of emitting an empty object.
+     */
+    @JsonValue
+    public abstract Object raw();
+
+    public static final class Unweighted extends KtValue {
+        private final String threshold;
+
+        private Unweighted(String threshold) {
+            this.threshold = Objects.requireNonNull(threshold, "threshold");
+        }
+
+        public String threshold() {
+            return threshold;
+        }
+
+        @Override
+        public Object raw() {
+            return threshold;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof Unweighted other && threshold.equals(other.threshold);
+        }
+
+        @Override
+        public int hashCode() {
+            return threshold.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "KtValue.Unweighted(" + threshold + ")";
+        }
+    }
+
+    public static final class Weighted extends KtValue {
+        private final List<?> weights;
+
+        private Weighted(List<?> weights) {
+            this.weights = List.copyOf(Objects.requireNonNull(weights, "weights"));
+        }
+
+        public List<?> weights() {
+            return weights;
+        }
+
+        @Override
+        public Object raw() {
+            return weights;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof Weighted other && weights.equals(other.weights);
+        }
+
+        @Override
+        public int hashCode() {
+            return weights.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "KtValue.Weighted(" + weights + ")";
+        }
+    }
+}

--- a/src/test/java/org/cardanofoundation/signify/app/config/KtValueTest.java
+++ b/src/test/java/org/cardanofoundation/signify/app/config/KtValueTest.java
@@ -1,0 +1,104 @@
+package org.cardanofoundation.signify.app.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import org.cardanofoundation.signify.generated.keria.model.KeyStateRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class KtValueTest {
+
+    private static ObjectMapper mapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        GeneratedModelConfig.configure(mapper);
+        return mapper;
+    }
+
+    @Test
+    @DisplayName("kt/nt deserialize to KtValue carrying the raw threshold")
+    void deserializeThresholds() throws Exception {
+        KeyStateRecord state = mapper().readValue(
+            "{\"kt\":\"1\",\"nt\":[\"1/2\",\"1/2\"]}", KeyStateRecord.class);
+
+        assertEquals("1", KtValue.rawOf(state.getKt()));
+        assertEquals(List.of("1/2", "1/2"), KtValue.rawOf(state.getNt()));
+    }
+
+    @Test
+    @DisplayName("nested multi-clause weighted thresholds are preserved")
+    void deserializeNestedWeightedThreshold() throws Exception {
+        KeyStateRecord state = mapper().readValue(
+            "{\"kt\":[[\"1/2\",\"1/2\"],[\"1\"]],\"nt\":\"2\"}", KeyStateRecord.class);
+
+        assertEquals(List.of(List.of("1/2", "1/2"), List.of("1")), KtValue.rawOf(state.getKt()));
+        assertEquals("2", KtValue.rawOf(state.getNt()));
+    }
+
+    @Test
+    @DisplayName("distinct records keep distinct thresholds")
+    void noCrossInstanceAliasing() throws Exception {
+        ObjectMapper mapper = mapper();
+        KeyStateRecord first = mapper.readValue("{\"kt\":\"1\",\"nt\":\"2\"}", KeyStateRecord.class);
+        KeyStateRecord second = mapper.readValue("{\"kt\":\"3\",\"nt\":\"4\"}", KeyStateRecord.class);
+
+        assertEquals("1", KtValue.rawOf(first.getKt()));
+        assertEquals("2", KtValue.rawOf(first.getNt()));
+        assertEquals("3", KtValue.rawOf(second.getKt()));
+        assertEquals("4", KtValue.rawOf(second.getNt()));
+    }
+
+    @Test
+    @DisplayName("serialization round-trips the original kt/nt JSON")
+    void serializeRoundTrip() throws Exception {
+        ObjectMapper mapper = mapper();
+        KeyStateRecord state = mapper.readValue(
+            "{\"kt\":\"1\",\"nt\":[\"1/2\",\"1/2\"]}", KeyStateRecord.class);
+
+        JsonNode out = mapper.valueToTree(state);
+        assertTrue(out.get("kt").isTextual());
+        assertEquals("1", out.get("kt").asText());
+        assertTrue(out.get("nt").isArray());
+        assertEquals(List.of("1/2", "1/2"), mapper.convertValue(out.get("nt"), List.class));
+    }
+
+    @Test
+    @DisplayName("weighted and unweighted thresholds discriminate via exhaustive switch")
+    void discriminateViaSwitch() throws Exception {
+        KeyStateRecord state = mapper().readValue(
+            "{\"kt\":\"2\",\"nt\":[\"1/2\",\"1/2\"]}", KeyStateRecord.class);
+
+        Object kt = switch (KtValue.of(state.getKt())) {
+            case KtValue.Unweighted u -> u.threshold();
+            case KtValue.Weighted w -> w.weights();
+        };
+        Object nt = switch (KtValue.of(state.getNt())) {
+            case KtValue.Unweighted u -> u.threshold();
+            case KtValue.Weighted w -> w.weights();
+        };
+
+        assertEquals("2", kt);
+        assertEquals(List.of("1/2", "1/2"), nt);
+    }
+
+    @Test
+    @DisplayName("rawOf is null-safe for absent or non-KtValue fields")
+    void rawOfNullSafety() {
+        assertNull(KtValue.rawOf(null));
+        assertNull(KtValue.rawOf(new org.cardanofoundation.signify.generated.keria.model.KeyStateRecordKt()));
+    }
+
+    @Test
+    @DisplayName("unsupported JSON shapes fail loudly instead of returning an empty value")
+    void rejectsUnsupportedShape() {
+        assertThrows(MismatchedInputException.class, () ->
+            mapper().readValue("{\"kt\":{\"oops\":true},\"nt\":\"1\"}", KeyStateRecord.class));
+    }
+}


### PR DESCRIPTION
Known issue from https://github.com/cardano-foundation/cf-signify-java/pull/89 - split fix to this PR for history. Verified this works properly with e2e tests locally too.